### PR TITLE
Create 美国罗切斯特大学哲学系.md

### DIFF
--- a/美国罗切斯特大学哲学系.md
+++ b/美国罗切斯特大学哲学系.md
@@ -1,0 +1,100 @@
+# 美国罗切斯特大学哲学系
+罗切斯特大学位于美国纽约州罗切斯特市，是一所私立研究型大学。其哲学系是世界领先的哲学研究中心之一，以其分析的严谨性和概念的清晰性而闻名。 1 分析的严谨性是指对论证和推理的重视，以及对清晰、精确的语言的追求。概念的清晰性是指对基本概念的深入理解和分析，以及对概念之间关系的阐明。 本文将深入探讨罗切斯特大学哲学系的各个方面，为有意向的学生提供全面的信息。
+教职员工
+罗切斯特大学哲学系拥有一支由 10 名全职教师组成的团队，他们在各个哲学领域都有着深厚的造诣。 2 系里的知名学者包括 Elizabeth Barnes，她是残疾哲学、女性主义哲学和形而上学领域的领军人物；Loren Lomasky，他是最有影响力的自由主义哲学家之一。 3 您可以通过访问哲学系的官方网站，找到所有教职员工的名单和联系方式。 4 哲学系办公室位于 River Campus 的 532 Lattimore Hall（参见地图）。同一楼层还有教师和助教办公室，以及该系的 Lewis White Beck 纪念图书馆，其中包含超过 10,000 册书籍和期刊。 4
+课程设置
+哲学系提供本科和研究生课程，涵盖了从哲学基础到高级研究的广泛主题。
+本科课程
+本科课程涵盖了哲学的主要分支，旨在培养学生的批判性思维、分析推理和清晰的写作能力。 这些技能不仅对未来从事哲学研究的学生至关重要，而且对任何寻求在各个领域取得成功的学生都非常宝贵。 主要课程包括：
+认识论
+伦理学
+哲学史
+逻辑学和数学哲学
+形而上学
+语言哲学
+心灵哲学
+社会和政治哲学 5
+除了这些核心领域，本科生还有机会参加 Berkeley Essay Prize 竞赛，该竞赛旨在鼓励和奖励优秀的哲学写作。 6
+研究生课程
+研究生课程则更加深入，学生可以选择特定领域进行深入研究，并与经验丰富的教师密切合作。 5 该系提供博士学位和硕士学位课程。博士课程为期五年，旨在培养学生成为独立的哲学研究者和学者。 5 该课程分为三个阶段：
+基础课程
+高级课程和集中研究
+论文 5
+哲学系还与认知科学、计算机科学、决策理论、经济学、教育学、语言学和心理学等学科有密切的合作，为学生提供跨学科学习的机会。 5 我们的项目与语言科学中心密切合作。 5 对认知科学、计算机科学、决策理论、经济学、教育学、语言学和心理学等领域有跨学科兴趣的哲学学生，将在罗切斯特大学的研究生学习期间找到发展这些兴趣的机会和鼓励。 5
+研究方向
+罗切斯特大学哲学系的研究方向主要集中在以下领域：
+认识论: 研究知识的本质、来源和局限性。
+伦理学: 探讨道德原则、价值观和行为规范。
+科学哲学: 研究科学知识的本质、方法和局限性。
+语言和心灵哲学: 探讨语言的本质、意义和心灵的哲学问题，例如意识、意向性和自由意志。
+形而上学: 研究存在、实在、时间和空间等基本问题。
+哲学史: 研究哲学思想的历史发展，包括古代哲学、近代哲学和当代哲学。 1
+该系的研究生项目以其分析的严谨性和概念的清晰性而闻名，鼓励学生在核心领域进行深入研究，并与其他学科进行对话。 1 该项目植根于分析哲学的核心领域，但经常与其他学科进行对话，其使命是解决哲学中最基本的问题以及对人类和其它领域研究进展具有重要意义的相关问题。 1
+学生生活
+除了严格的学术课程，罗切斯特大学哲学系还为学生提供丰富的课外活动和支持服务，以促进他们的智力成长和个人发展。
+哲学委员会
+哲学委员会是一个学生组织，为学生提供在课堂之外进行哲学讨论和参与的机会。 6 该委员会组织各种活动，例如：
+读书会
+哲学电影之夜
+客座讲座
+研讨会
+这些活动为学生提供了一个平台，让他们可以与同学和教师交流思想，探索不同的哲学观点，并加深对哲学的理解。
+研究生认识论会议
+研究生认识论会议是由研究生组织的两年一度的学术会议。 6 该会议邀请来自世界各地的哲学学者就认识论的最新研究成果进行交流和讨论。 这对研究生来说是一个宝贵的机会，可以展示他们的研究成果，与其他学者建立联系，并了解该领域的最新发展。
+学生人数
+截至 2023 年秋季，哲学系共有 28 名博士研究生和 2 名硕士研究生。 7 本科方面，春季学期有 37 名哲学专业学生，46 名辅修哲学的学生，3 名法律研究辅修的学生，以及 317 名参加哲学集群课程的学生。 7 哲学系的课程规模较小，研究生研讨会通常也只有少数学生参加，这促进了师生之间密切的互动和合作。 5 博士项目是罗切斯特大学哲学系知识生活的中心。该项目规模较小（约 10 名全职教师和 33 名博士生），博士生与教师密切合作。 2
+毕业生去向
+许多哲学专业的毕业生选择进入法学院深造，他们在哲学学习中培养的分析和批判性思维能力在法律领域非常有用。 8 其他毕业生则进入医学院、商学院、其他领域的研究生院或从事各种职业。 8 值得一提的是，罗切斯特大学的哲学专业毕业生申请法学院的录取率高达 95%，比全国平均水平高出 19%。 6 这突显了哲学系在培养学生批判性思维、分析推理和清晰的写作能力方面的成功，这些能力对法律专业的学生至关重要。
+排名和声誉
+罗切斯特大学哲学系在全美哲学博士项目中排名第 49 位。 9 在纽约州的哲学项目中排名第 6 位，在全美排名第 70 位。 10 该系以其分析的严谨性和概念的清晰性而闻名，并且在认识论、道德、社会和政治哲学、科学哲学、语言和心灵哲学、形而上学以及哲学史方面具有显著优势。 1
+招生信息
+申请条件
+哲学系博士项目的申请者需要提交以下材料：
+
+Requirement
+Details
+写作样本
+可以包括您在哲学本科课程中的作品。
+成绩单
+接受非官方成绩单，但录取后需要提供官方成绩单。
+三封推荐信
+来自熟悉您学术能力的教授或导师。
+个人陈述
+说明您为什么想攻读哲学研究生，为什么想在罗切斯特大学学习，以及您最感兴趣的哲学领域。
+已修哲学课程清单
+使用此表格 11
+英语语言能力考试成绩
+针对非英语母语申请者。 11
+
+非英语母语的申请者必须通过以下考试之一并达到最低分数来证明其英语语言能力：
+Duolingo 英语测试 – 120 分
+TOEFL 或 TOEFL iBT 家庭版 – 100 分
+IELTS – 7.5 分 11
+两年前的成绩无效。 11 选择提交托福成绩的学生可以提交在监考考点进行的托福 iBT 或纸笔考试的结果。也可能接受托福 iBT 特别家庭版考试或托福 ITP 评估。 11 托福成绩可以使用代码 2928 提交。 11
+如果申请人在美国或任何其他以英语为母语的国家完成了至少三年的全日制和面授高等教育学习，则也可以免除此要求。如果您有此学术背景并希望获得豁免，请发送电子邮件至 graduate.admissions@rochester.edu。 11
+招生委员会将酌情在录取通知书发出之前对非英语母语的申请人进行 Skype 面试。 11 无论申请人的背景或身份如何，哲学系保留要求进一步证明英语水平的权利。 11
+申请截止日期
+哲学系博士项目的申请截止日期为 2025 年 1 月 15 日。 11 建议尽早申请。
+申请费
+提交申请后，需支付 70 美元的不可退还申请费。 11 对于有经济需要的申请人，可以免除有限数量的申请费。如果您觉得难以负担这笔费用，可以通过电子邮件向 phladmin@philosophy.rochester.edu 解释您的经济状况，申请费用减免。 11
+经济援助和资金
+哲学系为研究生提供各种经济援助和资金机会，以帮助他们专注于学业。 这些机会包括：
+学费减免: 为未获得奖学金或助学金的学生提供学费减免。 12
+奖学金: 该系可能会提供奖学金以支持优秀的研究生。
+助学金: 研究生可能有资格获得助学金，以帮助支付生活费用和研究费用。
+有关经济援助和资金的更多信息，请参阅研究生手册或联系哲学系研究生招生办公室。 2
+总结
+罗切斯特大学哲学系是一个充满活力和学术严谨的学术社区，为学生提供了高质量的教育和研究机会。该系拥有优秀的师资力量、丰富的课程设置和广泛的研究方向，并且在哲学领域享有很高的声誉。 该系强调小班授课和师生之间的密切互动，为学生创造了一个支持性和协作性的学习环境。 2 此外，该系毕业生在申请法学院方面取得了骄人的成绩，这证明了该项目在培养学生批判性思维和分析推理能力方面的有效性。 6 如果您对哲学充满热情，并希望在一个充满智力挑战和支持的环境中学习，罗切斯特大学哲学系将是您理想的选择。
+Works cited
+1. A Brief History of Philosophy at the University of Rochester : About Us, accessed February 27, 2025, https://www.sas.rochester.edu/phl/about/history.html
+2. PhD Program : Graduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/graduate/phd.html
+3. What are the specialties of those colleges (umich, uva, unc, washu, cornell)? : r/askphilosophy - Reddit, accessed February 27, 2025, https://www.reddit.com/r/askphilosophy/comments/101qs8q/what_are_the_specialties_of_those_colleges_umich/
+4. People : Department of Philosophy - School of Arts & Sciences - University of Rochester, accessed February 27, 2025, https://www.sas.rochester.edu/phl/people/index.html
+5. Graduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/graduate/index.html
+6. Department of Philosophy : University of Rochester - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/
+7. Fast Facts : About Us : Department of Philosophy : University of Rochester, accessed February 27, 2025, https://www.sas.rochester.edu/phl/about/fast-facts.html
+8. Undergraduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/undergraduate/index.html
+9. Top 50 Philosophy Ph.D. programs in the U.S. for 2024-25 - Leiter Reports, accessed February 27, 2025, https://leiterreports.typepad.com/blog/2024/11/top-50-philosophy-phd-programs-in-the-us-for-2024-25.html
+10. University of Rochester: Philosophy Ranking 2024, accessed February 27, 2025, https://philosophy-colleges.com/university-of-rochester
+11. Applying : Graduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/graduate/apply.html
+12. Department of Philosophy - University of Rochester - Graduate Programs and Degrees, accessed February 27, 2025, https://www.petersons.com/graduate-schools/university-of-rochester-the-college-arts-and-sciences-department-of-philosophy-000_10047834.aspx


### PR DESCRIPTION
# 美国罗切斯特大学哲学系
罗切斯特大学位于美国纽约州罗切斯特市，是一所私立研究型大学。其哲学系是世界领先的哲学研究中心之一，以其分析的严谨性和概念的清晰性而闻名。 1 分析的严谨性是指对论证和推理的重视，以及对清晰、精确的语言的追求。概念的清晰性是指对基本概念的深入理解和分析，以及对概念之间关系的阐明。 本文将深入探讨罗切斯特大学哲学系的各个方面，为有意向的学生提供全面的信息。 教职员工
罗切斯特大学哲学系拥有一支由 10 名全职教师组成的团队，他们在各个哲学领域都有着深厚的造诣。 2 系里的知名学者包括 Elizabeth Barnes，她是残疾哲学、女性主义哲学和形而上学领域的领军人物；Loren Lomasky，他是最有影响力的自由主义哲学家之一。 3 您可以通过访问哲学系的官方网站，找到所有教职员工的名单和联系方式。 4 哲学系办公室位于 River Campus 的 532 Lattimore Hall（参见地图）。同一楼层还有教师和助教办公室，以及该系的 Lewis White Beck 纪念图书馆，其中包含超过 10,000 册书籍和期刊。 4 课程设置
哲学系提供本科和研究生课程，涵盖了从哲学基础到高级研究的广泛主题。
本科课程
本科课程涵盖了哲学的主要分支，旨在培养学生的批判性思维、分析推理和清晰的写作能力。 这些技能不仅对未来从事哲学研究的学生至关重要，而且对任何寻求在各个领域取得成功的学生都非常宝贵。 主要课程包括： 认识论
伦理学
哲学史
逻辑学和数学哲学
形而上学
语言哲学
心灵哲学
社会和政治哲学 5
除了这些核心领域，本科生还有机会参加 Berkeley Essay Prize 竞赛，该竞赛旨在鼓励和奖励优秀的哲学写作。 6 研究生课程
研究生课程则更加深入，学生可以选择特定领域进行深入研究，并与经验丰富的教师密切合作。 5 该系提供博士学位和硕士学位课程。博士课程为期五年，旨在培养学生成为独立的哲学研究者和学者。 5 该课程分为三个阶段： 基础课程
高级课程和集中研究
论文 5
哲学系还与认知科学、计算机科学、决策理论、经济学、教育学、语言学和心理学等学科有密切的合作，为学生提供跨学科学习的机会。 5 我们的项目与语言科学中心密切合作。 5 对认知科学、计算机科学、决策理论、经济学、教育学、语言学和心理学等领域有跨学科兴趣的哲学学生，将在罗切斯特大学的研究生学习期间找到发展这些兴趣的机会和鼓励。 5 研究方向
罗切斯特大学哲学系的研究方向主要集中在以下领域：
认识论: 研究知识的本质、来源和局限性。
伦理学: 探讨道德原则、价值观和行为规范。
科学哲学: 研究科学知识的本质、方法和局限性。
语言和心灵哲学: 探讨语言的本质、意义和心灵的哲学问题，例如意识、意向性和自由意志。
形而上学: 研究存在、实在、时间和空间等基本问题。
哲学史: 研究哲学思想的历史发展，包括古代哲学、近代哲学和当代哲学。 1
该系的研究生项目以其分析的严谨性和概念的清晰性而闻名，鼓励学生在核心领域进行深入研究，并与其他学科进行对话。 1 该项目植根于分析哲学的核心领域，但经常与其他学科进行对话，其使命是解决哲学中最基本的问题以及对人类和其它领域研究进展具有重要意义的相关问题。 1 学生生活
除了严格的学术课程，罗切斯特大学哲学系还为学生提供丰富的课外活动和支持服务，以促进他们的智力成长和个人发展。 哲学委员会
哲学委员会是一个学生组织，为学生提供在课堂之外进行哲学讨论和参与的机会。 6 该委员会组织各种活动，例如： 读书会
哲学电影之夜
客座讲座
研讨会
这些活动为学生提供了一个平台，让他们可以与同学和教师交流思想，探索不同的哲学观点，并加深对哲学的理解。 研究生认识论会议
研究生认识论会议是由研究生组织的两年一度的学术会议。 6 该会议邀请来自世界各地的哲学学者就认识论的最新研究成果进行交流和讨论。 这对研究生来说是一个宝贵的机会，可以展示他们的研究成果，与其他学者建立联系，并了解该领域的最新发展。 学生人数
截至 2023 年秋季，哲学系共有 28 名博士研究生和 2 名硕士研究生。 7 本科方面，春季学期有 37 名哲学专业学生，46 名辅修哲学的学生，3 名法律研究辅修的学生，以及 317 名参加哲学集群课程的学生。 7 哲学系的课程规模较小，研究生研讨会通常也只有少数学生参加，这促进了师生之间密切的互动和合作。 5 博士项目是罗切斯特大学哲学系知识生活的中心。该项目规模较小（约 10 名全职教师和 33 名博士生），博士生与教师密切合作。 2 毕业生去向
许多哲学专业的毕业生选择进入法学院深造，他们在哲学学习中培养的分析和批判性思维能力在法律领域非常有用。 8 其他毕业生则进入医学院、商学院、其他领域的研究生院或从事各种职业。 8 值得一提的是，罗切斯特大学的哲学专业毕业生申请法学院的录取率高达 95%，比全国平均水平高出 19%。 6 这突显了哲学系在培养学生批判性思维、分析推理和清晰的写作能力方面的成功，这些能力对法律专业的学生至关重要。 排名和声誉
罗切斯特大学哲学系在全美哲学博士项目中排名第 49 位。 9 在纽约州的哲学项目中排名第 6 位，在全美排名第 70 位。 10 该系以其分析的严谨性和概念的清晰性而闻名，并且在认识论、道德、社会和政治哲学、科学哲学、语言和心灵哲学、形而上学以及哲学史方面具有显著优势。 1 招生信息
申请条件
哲学系博士项目的申请者需要提交以下材料：

Requirement
Details
写作样本
可以包括您在哲学本科课程中的作品。
成绩单
接受非官方成绩单，但录取后需要提供官方成绩单。
三封推荐信
来自熟悉您学术能力的教授或导师。
个人陈述
说明您为什么想攻读哲学研究生，为什么想在罗切斯特大学学习，以及您最感兴趣的哲学领域。
已修哲学课程清单
使用此表格 11
英语语言能力考试成绩
针对非英语母语申请者。 11

非英语母语的申请者必须通过以下考试之一并达到最低分数来证明其英语语言能力：
Duolingo 英语测试 – 120 分
TOEFL 或 TOEFL iBT 家庭版 – 100 分
IELTS – 7.5 分 11
两年前的成绩无效。 11 选择提交托福成绩的学生可以提交在监考考点进行的托福 iBT 或纸笔考试的结果。也可能接受托福 iBT 特别家庭版考试或托福 ITP 评估。 11 托福成绩可以使用代码 2928 提交。 11 如果申请人在美国或任何其他以英语为母语的国家完成了至少三年的全日制和面授高等教育学习，则也可以免除此要求。如果您有此学术背景并希望获得豁免，请发送电子邮件至 graduate.admissions@rochester.edu。 11 招生委员会将酌情在录取通知书发出之前对非英语母语的申请人进行 Skype 面试。 11 无论申请人的背景或身份如何，哲学系保留要求进一步证明英语水平的权利。 11 申请截止日期
哲学系博士项目的申请截止日期为 2025 年 1 月 15 日。 11 建议尽早申请。
申请费
提交申请后，需支付 70 美元的不可退还申请费。 11 对于有经济需要的申请人，可以免除有限数量的申请费。如果您觉得难以负担这笔费用，可以通过电子邮件向 phladmin@philosophy.rochester.edu 解释您的经济状况，申请费用减免。 11 经济援助和资金
哲学系为研究生提供各种经济援助和资金机会，以帮助他们专注于学业。 这些机会包括：
学费减免: 为未获得奖学金或助学金的学生提供学费减免。 12
奖学金: 该系可能会提供奖学金以支持优秀的研究生。
助学金: 研究生可能有资格获得助学金，以帮助支付生活费用和研究费用。
有关经济援助和资金的更多信息，请参阅研究生手册或联系哲学系研究生招生办公室。 2
总结
罗切斯特大学哲学系是一个充满活力和学术严谨的学术社区，为学生提供了高质量的教育和研究机会。该系拥有优秀的师资力量、丰富的课程设置和广泛的研究方向，并且在哲学领域享有很高的声誉。 该系强调小班授课和师生之间的密切互动，为学生创造了一个支持性和协作性的学习环境。 2 此外，该系毕业生在申请法学院方面取得了骄人的成绩，这证明了该项目在培养学生批判性思维和分析推理能力方面的有效性。 6 如果您对哲学充满热情，并希望在一个充满智力挑战和支持的环境中学习，罗切斯特大学哲学系将是您理想的选择。 Works cited
1. A Brief History of Philosophy at the University of Rochester : About Us, accessed February 27, 2025, https://www.sas.rochester.edu/phl/about/history.html
2. PhD Program : Graduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/graduate/phd.html
3. What are the specialties of those colleges (umich, uva, unc, washu, cornell)? : r/askphilosophy - Reddit, accessed February 27, 2025, https://www.reddit.com/r/askphilosophy/comments/101qs8q/what_are_the_specialties_of_those_colleges_umich/
4. People : Department of Philosophy - School of Arts & Sciences - University of Rochester, accessed February 27, 2025, https://www.sas.rochester.edu/phl/people/index.html
5. Graduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/graduate/index.html
6. Department of Philosophy : University of Rochester - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/
7. Fast Facts : About Us : Department of Philosophy : University of Rochester, accessed February 27, 2025, https://www.sas.rochester.edu/phl/about/fast-facts.html
8. Undergraduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/undergraduate/index.html
9. Top 50 Philosophy Ph.D. programs in the U.S. for 2024-25 - Leiter Reports, accessed February 27, 2025, https://leiterreports.typepad.com/blog/2024/11/top-50-philosophy-phd-programs-in-the-us-for-2024-25.html
10. University of Rochester: Philosophy Ranking 2024, accessed February 27, 2025, https://philosophy-colleges.com/university-of-rochester
11. Applying : Graduate Program : Department of Philosophy - School of Arts & Sciences, accessed February 27, 2025, https://www.sas.rochester.edu/phl/graduate/apply.html
12. Department of Philosophy - University of Rochester - Graduate Programs and Degrees, accessed February 27, 2025, https://www.petersons.com/graduate-schools/university-of-rochester-the-college-arts-and-sciences-department-of-philosophy-000_10047834.aspx